### PR TITLE
feat: enable using keyboard

### DIFF
--- a/script.js
+++ b/script.js
@@ -109,12 +109,15 @@ function displayDigitOrDecimalWithKeyboard(e) {
         decimalBtn.click();
     } else if (inputIsDigit) {
         const equivalentBtn = document.querySelector(`.btn${e.key}`);
+        equivalentBtn.dispatchEvent(new Event("mousedown"));
         equivalentBtn.click();
     };
 };
 
 document.body.addEventListener("keydown", displayDigitOrDecimalWithKeyboard);
 document.body.addEventListener("mouseup", () =>
+    digitBtns.forEach(btn => btn.classList.remove("btn-clicked")));
+document.body.addEventListener("keyup", () =>
     digitBtns.forEach(btn => btn.classList.remove("btn-clicked")));
 
 clearBtn.addEventListener("click", () => location.reload());

--- a/script.js
+++ b/script.js
@@ -104,26 +104,34 @@ function handleBackspace() {
 
 function inputFromKeyboard(e) {
     console.log(e.key);
+    console.log(operatorBtns);
+    // console.log(Array.from(operatorBtns));
 
     const inputIsDigit = !isNaN(e.key);
-    if (e.key == ".") {
-        decimalBtn.dispatchEvent(new Event("mousedown"));
-        decimalBtn.click();
-        return
-    };
     if (inputIsDigit) {
         const equivalentBtn = document.querySelector(`.btn${e.key}`);
         equivalentBtn.dispatchEvent(new Event("mousedown"));
         equivalentBtn.click();
         return;
-    }
+    };
+    if (e.key == ".") {
+        decimalBtn.dispatchEvent(new Event("mousedown"));
+        decimalBtn.click();
+        return;
+    };
 
-    const btnToKeyMap = {
+    const operatorMap = {
+        "+": "+",
+        "−": "-",
+        "×": ["*", "x", "X"],
+        "÷": "/"
+    };
+
+    const btnToKey = {
         clearBtn: ["A", "a", "C", "c", "Escape"],
         backspaceBtn: ["Backspace", "Delete"],
         equalsBtn: ["Enter", "="],
         decimalBtn: ".",
-
     }
 };
 

--- a/script.js
+++ b/script.js
@@ -115,8 +115,10 @@ function displayDigitOrDecimalWithKeyboard(e) {
 };
 
 document.body.addEventListener("keydown", displayDigitOrDecimalWithKeyboard);
-document.body.addEventListener("mouseup", () =>
-    digitBtns.forEach(btn => btn.classList.remove("btn-clicked")));
+document.body.addEventListener("mouseup", () => {
+    digitBtns.forEach(btn => btn.classList.remove("btn-clicked"));
+    backspaceBtn.classList.remove("btn-clicked");
+})
 document.body.addEventListener("keyup", () =>
     digitBtns.forEach(btn => btn.classList.remove("btn-clicked")));
 

--- a/script.js
+++ b/script.js
@@ -106,10 +106,10 @@ function displayDigitOrDecimalWithKeyboard(e) {
     const keyInput = e.key;
     const inputIsDigit = !isNaN(keyInput);
     if (keyInput == ".") addDecimal();
-    // if (inputIsDigit) displayDigit(keyInput);
+    if (inputIsDigit) displayDigit(keyInput);
 }; 3
 
-document.addEventListener("keyup", displayDigitOrDecimalWithKeyboard);
+document.addEventListener("keydown", displayDigitOrDecimalWithKeyboard);
 clearBtn.addEventListener("click", () => location.reload());
 backspaceBtn.addEventListener("click", handleBackspace);
 digitBtns.forEach(btn => btn.addEventListener("click", displayDigit));

--- a/script.js
+++ b/script.js
@@ -103,17 +103,13 @@ function handleBackspace() {
 };
 
 function displayDigitOrDecimalWithKeyboard(e) {
+    const inputIsDigit = !isNaN(e.key);
     if (e.key == ".") {
         decimalBtn.dispatchEvent(new Event("mousedown"));
         addDecimal();
-        return;
+    } else if (inputIsDigit) {
+        displayDigit(e);
     };
-    const inputIsDigit = !isNaN(e.key);
-    if (inputIsDigit) displayDigit(e);
-
-    // function styleEquivalentBtnAsClicked() {
-    //     digitBtns.forEach(digitBtn => digitBtn.classList.add(digitBtn.textContent));
-    // }
 };
 
 document.addEventListener("keydown", displayDigitOrDecimalWithKeyboard);

--- a/script.js
+++ b/script.js
@@ -106,6 +106,8 @@ function inputFromKeyboard(e) {
     console.log(e.key);
     // console.log(Array.from(operatorBtns));
 
+
+    // todo: switch/case statement probably best here
     let equivalentBtn;
     const inputIsDigit = !isNaN(e.key);
     if (inputIsDigit) {
@@ -119,14 +121,26 @@ function inputFromKeyboard(e) {
         decimalBtn.click();
         return;
     };
-    equivalentBtn = Array.from(allBtns).find((btn) => btn.textContent == e.key);
-    if (!equivalentBtn) {
-        console.log("btn not found");
-        return;
-    }
+
+    const operatorKeys = new Set(["+", "-", "*", "x", "/"]);
+    // if (e.key)
 
 
-    console.log(equivalentBtn);
+    //todo: need to lowercase e.key when checking
+
+    // PSEUDOCODE: IF THE KEY IS AN OPERATOR, THEN FIND EQUIVALENT OPERATOR BTTN, AND DO THE ABOVE
+    // PSEUDOCODE: IF THE KEY IS NOT AN OPERATOR (ELSE), THEN FIND EQUIVALENT BTN AND DO THE ABOVE
+
+    // 
+
+    // equivalentBtn = Array.from(allBtns).find((btn) => btn.textContent == e.key);
+    // if (!equivalentBtn) {
+    //     console.log("btn not found");
+    //     return;
+    // }
+
+
+    // console.log(equivalentBtn);
 
     // const operatorMap = {
     //     "+": "+",
@@ -136,12 +150,14 @@ function inputFromKeyboard(e) {
     // };
     // console.log(Object.entries(operatorMap));
 
-    // const btnToKey = {
-    //     clearBtn: ["A", "a", "C", "c", "Escape"],
-    //     backspaceBtn: ["Backspace", "Delete"],
-    //     equalsBtn: ["Enter", "="],
-    //     decimalBtn: ".",
-    // }
+    const btnToKey = {
+        clearBtn: ["A", "a", "C", "c", "Escape"],
+        backspaceBtn: ["Backspace", "Delete"],
+        equalsBtn: ["Enter", "="],
+        decimalBtn: ".",
+    }
+
+    // console.log(new Set(Object.values(btnToKey).flat()))
 };
 
 

--- a/script.js
+++ b/script.js
@@ -140,14 +140,10 @@ function inputFromKeyboard(e) {
         backspaceBtn.click();
     };
 
-
-    // const operatorMap = {
-    //     "+": "+",
-    //     "−": "-",
-    //     "×": ["*", "x", "X"],
-    //     "÷": "/"
-    // };
-    // console.log(Object.entries(operatorMap));
+    if (input === "enter" || input === "=") {
+        equalsBtn.dispatchEvent(new Event("mousedown"));
+        equalsBtn.click();
+    }
 
     // const btnToKey = {
     //     clearBtn: ["A", "a", "C", "c", "Escape"],
@@ -167,12 +163,14 @@ document.body.addEventListener("keydown", inputFromKeyboard);
 document.body.addEventListener("mouseup", () => {
     digitBtns.forEach(btn => btn.classList.remove("btn-clicked"));
     backspaceBtn.classList.remove("btn-clicked");
-})
+    equalsBtn.classList.remove("btn-clicked");
+});
 document.body.addEventListener("keyup", () => {
     digitBtns.forEach(btn => btn.classList.remove("btn-clicked"));
     backspaceBtn.classList.remove("btn-clicked");
-}
-);
+    equalsBtn.classList.remove("btn-clicked");
+});
+//? potentially can have a class of buttons that "non-held" that would all just have its classes removed when key up or mouse up anywhere on the document!!
 
 clearBtn.addEventListener("click", () => location.reload());
 backspaceBtn.addEventListener("click", handleBackspace);

--- a/script.js
+++ b/script.js
@@ -102,8 +102,9 @@ function handleBackspace() {
     display.value = display.value.length > 1 ? display.value.slice(0, -1) : 0;
 };
 
-function displayDigitOrDecimalWithKeyboard(e) {
+function inputFromKeyboard(e) {
     const inputIsDigit = !isNaN(e.key);
+
     if (e.key == ".") {
         decimalBtn.dispatchEvent(new Event("mousedown"));
         decimalBtn.click();
@@ -114,7 +115,7 @@ function displayDigitOrDecimalWithKeyboard(e) {
     };
 };
 
-document.body.addEventListener("keydown", displayDigitOrDecimalWithKeyboard);
+document.body.addEventListener("keydown", inputFromKeyboard);
 document.body.addEventListener("mouseup", () => {
     digitBtns.forEach(btn => btn.classList.remove("btn-clicked"));
     backspaceBtn.classList.remove("btn-clicked");

--- a/script.js
+++ b/script.js
@@ -1,6 +1,6 @@
 const display = document.querySelector(".display");
 
-const MAXCHARSDISPLAYED = 10;
+const MAXCHARSDISPLAYED = 9;
 
 const digitBtns = document.querySelectorAll(".digit");
 const operatorBtns = document.querySelectorAll(".operator");
@@ -49,7 +49,7 @@ function displayDigit(e) {
         display.value = "";
         displayNeedsClearing = false;
     } else if (display.value.length >= MAXCHARSDISPLAYED) return;
-    display.value += e.target.textContent;
+    display.value += e.key || e.target.textContent;
     return;
 };
 
@@ -103,11 +103,10 @@ function handleBackspace() {
 };
 
 function displayDigitOrDecimalWithKeyboard(e) {
-    const keyInput = e.key;
-    const inputIsDigit = !isNaN(keyInput);
-    if (keyInput == ".") addDecimal();
-    if (inputIsDigit) displayDigit(keyInput);
-}; 3
+    const inputIsDigit = !isNaN(e.key);
+    if (e.key == ".") addDecimal();
+    if (inputIsDigit) displayDigit(e);
+};
 
 document.addEventListener("keydown", displayDigitOrDecimalWithKeyboard);
 clearBtn.addEventListener("click", () => location.reload());

--- a/script.js
+++ b/script.js
@@ -105,6 +105,7 @@ function handleBackspace() {
 function inputFromKeyboard(e) {
     const input = e.key.toLowerCase();
     const inputIsDigit = !isNaN(input);
+    const inputIsDecimal = input === ".";
     const operatorKeys = new Set(["+", "-", "*", "x", "/"]);
     const operatorMap = {
         "+": "+",
@@ -121,49 +122,16 @@ function inputFromKeyboard(e) {
 
     const equivalentBtn =
         inputIsDigit ? getEquivalentDigitBtn()
-            : isInCategory(operatorKeys) ? Array.from(operatorBtns).find(btn => btn.textContent == operatorMap[input])
-                : isInCategory(backspaceKeys) ? backspaceBtn
-                    : isInCategory(clearKeys) ? clearBtn
-                        : isInCategory(equalsKeys) ? equalsBtn
+            : inputIsDecimal ? decimalBtn
+                : isInCategory(operatorKeys) ? Array.from(operatorBtns).find(btn => btn.textContent == operatorMap[input])
+                    : isInCategory(backspaceKeys) ? backspaceBtn
+                        : isInCategory(clearKeys) ? clearBtn
+                            : isInCategory(equalsKeys) ? equalsBtn : undefined;
 
+    if (!equivalentBtn) return;
+
+    equivalentBtn.dispatchEvent(new Event("mousedown"));
     equivalentBtn.click();
-
-
-    // let equivalentBtn;
-
-    // if (inputIsDigit) {
-    //     equivalentBtn = document.querySelector(`.btn${input}`);
-    //     equivalentBtn.dispatchEvent(new Event("mousedown"));
-    //     equivalentBtn.click();
-    //     return;
-    // };
-    // if (input == ".") {
-    //     decimalBtn.dispatchEvent(new Event("mousedown"));
-    //     decimalBtn.click();
-    //     return;
-    // };
-    // if (operatorKeys.has(input)) {
-    //     const operatorMap = {
-    //         "+": "+",
-    //         "-": "−",
-    //         "*": "×",
-    //         "x": "×",
-    //         "/": "÷"
-    //     };
-    //     equivalentBtn = Array.from(operatorBtns).find(
-    //         btn => btn.textContent == operatorMap[input]);
-    //     equivalentBtn.click();
-    // };
-
-    // if (input === "backspace" || input === "delete") {
-    //     backspaceBtn.dispatchEvent(new Event("mousedown"));
-    //     backspaceBtn.click();
-    // };
-    // if (input === "enter" || input === "=") {
-    //     equalsBtn.dispatchEvent(new Event("mousedown"));
-    //     equalsBtn.click();
-    // };
-    // if (clearKeys.has(input)) clearBtn.click();
 };
 
 

--- a/script.js
+++ b/script.js
@@ -48,7 +48,7 @@ function displayDigit(e) {
     if (display.value === "0" || displayNeedsClearing) {
         display.value = "";
         displayNeedsClearing = false;
-    } else if (display.value.length >= MAXCHARSDISPLAYED) return;
+    } else if (display.value.length >= MAX_CHARS_DISPLAYED) return;
     display.value += e.target.textContent;
     return;
 };
@@ -74,7 +74,7 @@ function handleOperationBtnClick(e) {
     } else {
         num2 = display.value;
         calculationResult = operate(num1, num2, operator);
-        display.value = calculationResult.toString().length >= MAXCHARSDISPLAYED ?
+        display.value = calculationResult.toString().length >= MAX_CHARS_DISPLAYED ?
             calculationResult.toPrecision(5) : calculationResult;
         num1 = calculationResult;
     };
@@ -89,7 +89,7 @@ function handleEqualBtnClick() {
     if (num1 === null || !secondNumberInputted) return;
     num2 = display.value;
     calculationResult = operate(num1, num2, operator);
-    display.value = calculationResult.toString().length > MAXCHARSDISPLAYED ?
+    display.value = calculationResult.toString().length > MAX_CHARS_DISPLAYED ?
         calculationResult.toPrecision(5) : calculationResult;
     displayNeedsClearing = true;
     secondNumberInputted = false;
@@ -107,13 +107,16 @@ function inputFromKeyboard(e) {
     if (e.key == ".") {
         decimalBtn.dispatchEvent(new Event("mousedown"));
         decimalBtn.click();
-    } else if (inputIsDigit) {
+        return
+    };
+    if (inputIsDigit) {
         const equivalentBtn = document.querySelector(`.btn${e.key}`);
         equivalentBtn.dispatchEvent(new Event("mousedown"));
         equivalentBtn.click();
-    } else {
-        const KEY_TO_BTN = {}
-    };
+        return;
+    }
+    // const keyToBtnMap = {
+    // }
 };
 
 

--- a/script.js
+++ b/script.js
@@ -104,10 +104,13 @@ function handleBackspace() {
 
 function inputFromKeyboard(e) {
     const input = e.key.toLowerCase();
+    const inputIsDigit = !isNaN(input);
+    const operatorKeys = new Set(["+", "-", "*", "x", "/"]);
+    const clearKeys = new Set(["a", "c", "escape"]);
 
     // todo: switch/case statement probably best here
     let equivalentBtn;
-    const inputIsDigit = !isNaN(input);
+
     if (inputIsDigit) {
         equivalentBtn = document.querySelector(`.btn${input}`);
         equivalentBtn.dispatchEvent(new Event("mousedown"));
@@ -119,8 +122,6 @@ function inputFromKeyboard(e) {
         decimalBtn.click();
         return;
     };
-
-    const operatorKeys = new Set(["+", "-", "*", "x", "/"]);
     if (operatorKeys.has(input)) {
         const operatorMap = {
             "+": "+",
@@ -142,13 +143,8 @@ function inputFromKeyboard(e) {
         equalsBtn.dispatchEvent(new Event("mousedown"));
         equalsBtn.click();
     };
-
-    const clearKeys = new Set(["a", "c", "escape"]);
     if (clearKeys.has(input)) clearBtn.click();
 };
-
-
-// TODO: "C" FOR CLEAR, "A" FOR CLEAR, "BACKSPACE" FOR BACKSPACE, ---"SHIFT+" OR "SHIFT-" TO CHANGE POSTIVIE/NEGATIVE---, "/" FOR DIVIDE, "*" OR "X" FOR MULTIPLY, "-" FOR MINUS", "+" FOR PLUS, "ENTER" FOR EQUALS
 
 
 document.body.addEventListener("keydown", inputFromKeyboard);

--- a/script.js
+++ b/script.js
@@ -1,6 +1,6 @@
 const display = document.querySelector(".display");
 
-const MAXCHARSDISPLAYED = 9;
+const MAX_CHARS_DISPLAYED = 9;
 
 const digitBtns = document.querySelectorAll(".digit");
 const operatorBtns = document.querySelectorAll(".operator");
@@ -104,7 +104,6 @@ function handleBackspace() {
 
 function inputFromKeyboard(e) {
     const inputIsDigit = !isNaN(e.key);
-
     if (e.key == ".") {
         decimalBtn.dispatchEvent(new Event("mousedown"));
         decimalBtn.click();
@@ -112,8 +111,14 @@ function inputFromKeyboard(e) {
         const equivalentBtn = document.querySelector(`.btn${e.key}`);
         equivalentBtn.dispatchEvent(new Event("mousedown"));
         equivalentBtn.click();
+    } else {
+        const KEY_TO_BTN = {}
     };
 };
+
+
+// TODO: "C" FOR CLEAR, "A" FOR CLEAR, "BACKSPACE" FOR BACKSPACE, "SHIFT+" OR "SHIFT-" TO CHANGE POSTIVIE/NEGATIVE, "/" FOR DIVIDE, "*" OR "X" FOR MULTIPLY, "-" FOR MINUS", "+" FOR PLUS, "ENTER" FOR EQUALS
+
 
 document.body.addEventListener("keydown", inputFromKeyboard);
 document.body.addEventListener("mouseup", () => {

--- a/script.js
+++ b/script.js
@@ -103,21 +103,22 @@ function handleBackspace() {
 };
 
 function displayDigitOrDecimalWithKeyboard(e) {
-    if (e.key == ".") {
-        decimalBtn.dispatchEvent(new Event("mousedown"));
-        decimalBtn.dispatchEvent(new Event("mouseup"));
-        decimalBtn.dispatchEvent(new Event("click"));
-    };
-
-
+    if (e.key == ".") addDecimal();
     const inputIsDigit = !isNaN(e.key);
     if (inputIsDigit) displayDigit(e);
+
+    // function styleEquivalentBtnAsClicked() {
+    //     digitBtns.forEach(digitBtn => digitBtn.classList.add(digitBtn.textContent));
+    // }
 };
 
 document.addEventListener("keydown", displayDigitOrDecimalWithKeyboard);
 clearBtn.addEventListener("click", () => location.reload());
 backspaceBtn.addEventListener("click", handleBackspace);
-digitBtns.forEach(btn => btn.addEventListener("click", displayDigit));
+digitBtns.forEach(btn => {
+    btn.classList.add(btn.textContent);
+    btn.addEventListener("click", displayDigit);
+});
 negativeBtn.addEventListener("click", () => display.value = display.value * -1);
 operatorBtns.forEach(btn => btn.addEventListener("click", handleOperationBtnClick));
 decimalBtn.addEventListener("click", addDecimal);

--- a/script.js
+++ b/script.js
@@ -49,7 +49,7 @@ function displayDigit(e) {
         display.value = "";
         displayNeedsClearing = false;
     } else if (display.value.length >= MAXCHARSDISPLAYED) return;
-    display.value += e.key || e.target.textContent;
+    display.value += e.target.textContent;
     return;
 };
 
@@ -106,9 +106,10 @@ function displayDigitOrDecimalWithKeyboard(e) {
     const inputIsDigit = !isNaN(e.key);
     if (e.key == ".") {
         decimalBtn.dispatchEvent(new Event("mousedown"));
-        addDecimal();
+        decimalBtn.click();
     } else if (inputIsDigit) {
-        displayDigit(e);
+        const equivalentBtn = document.querySelector(`.btn${e.key}`);
+        equivalentBtn.click();
     };
 };
 

--- a/script.js
+++ b/script.js
@@ -116,7 +116,6 @@ negativeBtn.addEventListener("click", () => display.value = display.value * -1);
 operatorBtns.forEach(btn => btn.addEventListener("click", handleOperationBtnClick));
 decimalBtn.addEventListener("click", addDecimal);
 equalsBtn.addEventListener("click", handleEqualBtnClick);
-
 allBtns.forEach(btn => {
     btn.addEventListener("mousedown", () => btn.classList.toggle("btn-clicked"));
     btn.addEventListener("click", () => operatorBtns.forEach(b => b.classList.remove("btn-held")))
@@ -131,9 +130,4 @@ operatorBtns.forEach(operatorBtn =>
         e.target.classList.add("btn-held");
     })
 );
-
 holdBtns.forEach(btn => btn.addEventListener("click", () => btn.classList.toggle("btn-held")));
-
-//TODO: (1) ADD EVENT LISTENER TO DOCUMENT. ONKEYUP. USE E.CODE(?). 
-
-//?HOW TO HAVE DISPLAYDIGIT TAKE IN THE DIGIT, AND NOT EVENT E PARAMETER??

--- a/script.js
+++ b/script.js
@@ -103,6 +103,8 @@ function handleBackspace() {
 };
 
 function inputFromKeyboard(e) {
+    e.preventDefault();
+
     const input = e.key.toLowerCase();
     const inputIsDigit = !isNaN(input);
     const inputIsDecimal = input === ".";
@@ -129,8 +131,7 @@ function inputFromKeyboard(e) {
                             : isInCategory(equalsKeys) ? equalsBtn : undefined;
 
     if (!equivalentBtn) return;
-
-    equivalentBtn.dispatchEvent(new Event("mousedown"));
+    if (!isInCategory(clearKeys)) equivalentBtn.dispatchEvent(new Event("mousedown"));
     equivalentBtn.click();
 };
 

--- a/script.js
+++ b/script.js
@@ -101,6 +101,10 @@ function handleBackspace() {
     display.value = display.value.length > 1 ? display.value.slice(0, -1) : 0;
 };
 
+function mapKeysToDigitButtons(e) {
+    return;
+};
+
 clearBtn.addEventListener("click", () => location.reload());
 backspaceBtn.addEventListener("click", handleBackspace);
 digitBtns.forEach(btn => btn.addEventListener("click", displayDigit));
@@ -125,3 +129,5 @@ operatorBtns.forEach(operatorBtn =>
 );
 
 holdBtns.forEach(btn => btn.addEventListener("click", () => btn.classList.toggle("btn-held")));
+
+//TODO: (1) ADD EVENT LISTENER TO DOCUMENT. ONKEYUP. USE E.CODE(?). 

--- a/script.js
+++ b/script.js
@@ -48,8 +48,9 @@ function displayDigit(e) {
     if (display.value === "0" || displayNeedsClearing) {
         display.value = "";
         displayNeedsClearing = false;
-    } else if (display.value.length == MAXCHARSDISPLAYED) return;
+    } else if (display.value.length >= MAXCHARSDISPLAYED) return;
     display.value += e.target.textContent;
+    return;
 };
 
 function addDecimal() {
@@ -101,12 +102,14 @@ function handleBackspace() {
     display.value = display.value.length > 1 ? display.value.slice(0, -1) : 0;
 };
 
-function mapKeysToDigitButtons(e) {
-    alert(e.key);
-    return;
-};
+function displayDigitOrDecimalWithKeyboard(e) {
+    const keyInput = e.key;
+    const inputIsDigit = !isNaN(keyInput);
+    if (keyInput == ".") addDecimal();
+    // if (inputIsDigit) displayDigit(keyInput);
+}; 3
 
-document.addEventListener("keyup", mapKeysToDigitButtons);
+document.addEventListener("keyup", displayDigitOrDecimalWithKeyboard);
 clearBtn.addEventListener("click", () => location.reload());
 backspaceBtn.addEventListener("click", handleBackspace);
 digitBtns.forEach(btn => btn.addEventListener("click", displayDigit));
@@ -133,3 +136,6 @@ operatorBtns.forEach(operatorBtn =>
 holdBtns.forEach(btn => btn.addEventListener("click", () => btn.classList.toggle("btn-held")));
 
 //TODO: (1) ADD EVENT LISTENER TO DOCUMENT. ONKEYUP. USE E.CODE(?). 
+
+//?HOW TO HAVE DISPLAYDIGIT TAKE IN THE DIGIT, AND NOT EVENT E PARAMETER??
+//!bug: can put in double decimals;

--- a/script.js
+++ b/script.js
@@ -106,44 +106,64 @@ function inputFromKeyboard(e) {
     const input = e.key.toLowerCase();
     const inputIsDigit = !isNaN(input);
     const operatorKeys = new Set(["+", "-", "*", "x", "/"]);
+    const operatorMap = {
+        "+": "+",
+        "-": "−",
+        "*": "×",
+        "x": "×",
+        "/": "÷"
+    };
+    const backspaceKeys = new Set(["backspace", "delete"]);
     const clearKeys = new Set(["a", "c", "escape"]);
+    const equalsKeys = new Set(["enter", "="]);
+    const isInCategory = categorySet => categorySet.has(input);
+    const getEquivalentDigitBtn = () => document.querySelector(`.btn${input}`)
 
-    // todo: switch/case statement probably best here
-    let equivalentBtn;
+    const equivalentBtn =
+        inputIsDigit ? getEquivalentDigitBtn()
+            : isInCategory(operatorKeys) ? Array.from(operatorBtns).find(btn => btn.textContent == operatorMap[input])
+                : isInCategory(backspaceKeys) ? backspaceBtn
+                    : isInCategory(clearKeys) ? clearBtn
+                        : isInCategory(equalsKeys) ? equalsBtn
 
-    if (inputIsDigit) {
-        equivalentBtn = document.querySelector(`.btn${input}`);
-        equivalentBtn.dispatchEvent(new Event("mousedown"));
-        equivalentBtn.click();
-        return;
-    };
-    if (input == ".") {
-        decimalBtn.dispatchEvent(new Event("mousedown"));
-        decimalBtn.click();
-        return;
-    };
-    if (operatorKeys.has(input)) {
-        const operatorMap = {
-            "+": "+",
-            "-": "−",
-            "*": "×",
-            "x": "×",
-            "/": "÷"
-        };
-        equivalentBtn = Array.from(operatorBtns).find(
-            btn => btn.textContent == operatorMap[input]);
-        equivalentBtn.click();
-    };
+    equivalentBtn.click();
 
-    if (input === "backspace" || input === "delete") {
-        backspaceBtn.dispatchEvent(new Event("mousedown"));
-        backspaceBtn.click();
-    };
-    if (input === "enter" || input === "=") {
-        equalsBtn.dispatchEvent(new Event("mousedown"));
-        equalsBtn.click();
-    };
-    if (clearKeys.has(input)) clearBtn.click();
+
+    // let equivalentBtn;
+
+    // if (inputIsDigit) {
+    //     equivalentBtn = document.querySelector(`.btn${input}`);
+    //     equivalentBtn.dispatchEvent(new Event("mousedown"));
+    //     equivalentBtn.click();
+    //     return;
+    // };
+    // if (input == ".") {
+    //     decimalBtn.dispatchEvent(new Event("mousedown"));
+    //     decimalBtn.click();
+    //     return;
+    // };
+    // if (operatorKeys.has(input)) {
+    //     const operatorMap = {
+    //         "+": "+",
+    //         "-": "−",
+    //         "*": "×",
+    //         "x": "×",
+    //         "/": "÷"
+    //     };
+    //     equivalentBtn = Array.from(operatorBtns).find(
+    //         btn => btn.textContent == operatorMap[input]);
+    //     equivalentBtn.click();
+    // };
+
+    // if (input === "backspace" || input === "delete") {
+    //     backspaceBtn.dispatchEvent(new Event("mousedown"));
+    //     backspaceBtn.click();
+    // };
+    // if (input === "enter" || input === "=") {
+    //     equalsBtn.dispatchEvent(new Event("mousedown"));
+    //     equalsBtn.click();
+    // };
+    // if (clearKeys.has(input)) clearBtn.click();
 };
 
 

--- a/script.js
+++ b/script.js
@@ -103,6 +103,8 @@ function handleBackspace() {
 };
 
 function inputFromKeyboard(e) {
+    console.log(e.key);
+
     const inputIsDigit = !isNaN(e.key);
     if (e.key == ".") {
         decimalBtn.dispatchEvent(new Event("mousedown"));
@@ -115,12 +117,18 @@ function inputFromKeyboard(e) {
         equivalentBtn.click();
         return;
     }
-    // const keyToBtnMap = {
-    // }
+
+    const btnToKeyMap = {
+        clearBtn: ["A", "a", "C", "c", "Escape"],
+        backspaceBtn: ["Backspace", "Delete"],
+        equalsBtn: ["Enter", "="],
+        decimalBtn: ".",
+
+    }
 };
 
 
-// TODO: "C" FOR CLEAR, "A" FOR CLEAR, "BACKSPACE" FOR BACKSPACE, "SHIFT+" OR "SHIFT-" TO CHANGE POSTIVIE/NEGATIVE, "/" FOR DIVIDE, "*" OR "X" FOR MULTIPLY, "-" FOR MINUS", "+" FOR PLUS, "ENTER" FOR EQUALS
+// TODO: "C" FOR CLEAR, "A" FOR CLEAR, "BACKSPACE" FOR BACKSPACE, ---"SHIFT+" OR "SHIFT-" TO CHANGE POSTIVIE/NEGATIVE---, "/" FOR DIVIDE, "*" OR "X" FOR MULTIPLY, "-" FOR MINUS", "+" FOR PLUS, "ENTER" FOR EQUALS
 
 
 document.body.addEventListener("keydown", inputFromKeyboard);

--- a/script.js
+++ b/script.js
@@ -128,31 +128,23 @@ function inputFromKeyboard(e) {
             "*": "×",
             "x": "×",
             "/": "÷"
-        }
+        };
         equivalentBtn = Array.from(operatorBtns).find(
-            btn => btn.textContent == operatorMap[input])
+            btn => btn.textContent == operatorMap[input]);
         equivalentBtn.click();
-        return;
     };
 
     if (input === "backspace" || input === "delete") {
         backspaceBtn.dispatchEvent(new Event("mousedown"));
         backspaceBtn.click();
     };
-
     if (input === "enter" || input === "=") {
         equalsBtn.dispatchEvent(new Event("mousedown"));
         equalsBtn.click();
-    }
+    };
 
-    // const btnToKey = {
-    //     clearBtn: ["A", "a", "C", "c", "Escape"],
-    //     backspaceBtn: ["Backspace", "Delete"],
-    //     equalsBtn: ["Enter", "="],
-    //     decimalBtn: ".",
-    // }
-
-    // console.log(new Set(Object.values(btnToKey).flat()))
+    const clearKeys = new Set(["a", "c", "escape"]);
+    if (clearKeys.has(input)) clearBtn.click();
 };
 
 

--- a/script.js
+++ b/script.js
@@ -124,29 +124,21 @@ function inputFromKeyboard(e) {
 
     const operatorKeys = new Set(["+", "-", "*", "x", "/"]);
     if (operatorKeys.has(input)) {
-        const operatorMap = { "*": "×", "x": "×", "/": "÷" }
+        const operatorMap = {
+            "+": "+",
+            "-": "−",
+            "*": "×",
+            "x": "×",
+            "/": "÷"
+        }
         equivalentBtn = Array.from(operatorBtns).find(
-            btn => btn.textContent == input || operatorMap[input])
+            btn => btn.textContent == operatorMap[input])
         equivalentBtn.click();
-    }
-    // if ((operatorKeys.has(e.key.lowerCase())))
+        return;
+    };
 
 
-    //todo: need to lowercase e.key when checking
 
-    // PSEUDOCODE: IF THE KEY IS AN OPERATOR, THEN FIND EQUIVALENT OPERATOR BTTN, AND DO THE ABOVE
-    // PSEUDOCODE: IF THE KEY IS NOT AN OPERATOR (ELSE), THEN FIND EQUIVALENT BTN AND DO THE ABOVE
-
-    // 
-
-    // equivalentBtn = Array.from(allBtns).find((btn) => btn.textContent == e.key);
-    // if (!equivalentBtn) {
-    //     console.log("btn not found");
-    //     return;
-    // }
-
-
-    // console.log(equivalentBtn);
 
     // const operatorMap = {
     //     "+": "+",

--- a/script.js
+++ b/script.js
@@ -102,9 +102,11 @@ function handleBackspace() {
 };
 
 function mapKeysToDigitButtons(e) {
+    alert(e.key);
     return;
 };
 
+document.addEventListener("keyup", mapKeysToDigitButtons);
 clearBtn.addEventListener("click", () => location.reload());
 backspaceBtn.addEventListener("click", handleBackspace);
 digitBtns.forEach(btn => btn.addEventListener("click", displayDigit));

--- a/script.js
+++ b/script.js
@@ -105,25 +105,31 @@ function handleBackspace() {
 function inputFromKeyboard(e) {
     console.log(e.key);
     // console.log(Array.from(operatorBtns));
-
+    const input = e.key.toLowerCase();
 
     // todo: switch/case statement probably best here
     let equivalentBtn;
-    const inputIsDigit = !isNaN(e.key);
+    const inputIsDigit = !isNaN(input);
     if (inputIsDigit) {
-        equivalentBtn = document.querySelector(`.btn${e.key}`);
+        equivalentBtn = document.querySelector(`.btn${input}`);
         equivalentBtn.dispatchEvent(new Event("mousedown"));
         equivalentBtn.click();
         return;
     };
-    if (e.key == ".") {
+    if (input == ".") {
         decimalBtn.dispatchEvent(new Event("mousedown"));
         decimalBtn.click();
         return;
     };
 
     const operatorKeys = new Set(["+", "-", "*", "x", "/"]);
-    // if (e.key)
+    if (operatorKeys.has(input)) {
+        const operatorMap = { "*": "×", "x": "×", "/": "÷" }
+        equivalentBtn = Array.from(operatorBtns).find(
+            btn => btn.textContent == input || operatorMap[input])
+        equivalentBtn.click();
+    }
+    // if ((operatorKeys.has(e.key.lowerCase())))
 
 
     //todo: need to lowercase e.key when checking
@@ -150,12 +156,12 @@ function inputFromKeyboard(e) {
     // };
     // console.log(Object.entries(operatorMap));
 
-    const btnToKey = {
-        clearBtn: ["A", "a", "C", "c", "Escape"],
-        backspaceBtn: ["Backspace", "Delete"],
-        equalsBtn: ["Enter", "="],
-        decimalBtn: ".",
-    }
+    // const btnToKey = {
+    //     clearBtn: ["A", "a", "C", "c", "Escape"],
+    //     backspaceBtn: ["Backspace", "Delete"],
+    //     equalsBtn: ["Enter", "="],
+    //     decimalBtn: ".",
+    // }
 
     // console.log(new Set(Object.values(btnToKey).flat()))
 };

--- a/script.js
+++ b/script.js
@@ -103,8 +103,14 @@ function handleBackspace() {
 };
 
 function displayDigitOrDecimalWithKeyboard(e) {
+    if (e.key == ".") {
+        decimalBtn.dispatchEvent(new Event("mousedown"));
+        decimalBtn.dispatchEvent(new Event("mouseup"));
+        decimalBtn.dispatchEvent(new Event("click"));
+    };
+
+
     const inputIsDigit = !isNaN(e.key);
-    if (e.key == ".") addDecimal();
     if (inputIsDigit) displayDigit(e);
 };
 

--- a/script.js
+++ b/script.js
@@ -103,8 +103,6 @@ function handleBackspace() {
 };
 
 function inputFromKeyboard(e) {
-    console.log(e.key);
-    // console.log(Array.from(operatorBtns));
     const input = e.key.toLowerCase();
 
     // todo: switch/case statement probably best here
@@ -137,7 +135,10 @@ function inputFromKeyboard(e) {
         return;
     };
 
-
+    if (input === "backspace" || input === "delete") {
+        backspaceBtn.dispatchEvent(new Event("mousedown"));
+        backspaceBtn.click();
+    };
 
 
     // const operatorMap = {
@@ -167,8 +168,11 @@ document.body.addEventListener("mouseup", () => {
     digitBtns.forEach(btn => btn.classList.remove("btn-clicked"));
     backspaceBtn.classList.remove("btn-clicked");
 })
-document.body.addEventListener("keyup", () =>
-    digitBtns.forEach(btn => btn.classList.remove("btn-clicked")));
+document.body.addEventListener("keyup", () => {
+    digitBtns.forEach(btn => btn.classList.remove("btn-clicked"));
+    backspaceBtn.classList.remove("btn-clicked");
+}
+);
 
 clearBtn.addEventListener("click", () => location.reload());
 backspaceBtn.addEventListener("click", handleBackspace);

--- a/script.js
+++ b/script.js
@@ -103,7 +103,11 @@ function handleBackspace() {
 };
 
 function displayDigitOrDecimalWithKeyboard(e) {
-    if (e.key == ".") addDecimal();
+    if (e.key == ".") {
+        decimalBtn.dispatchEvent(new Event("mousedown"));
+        addDecimal();
+        return;
+    };
     const inputIsDigit = !isNaN(e.key);
     if (inputIsDigit) displayDigit(e);
 

--- a/script.js
+++ b/script.js
@@ -116,7 +116,7 @@ document.addEventListener("keydown", displayDigitOrDecimalWithKeyboard);
 clearBtn.addEventListener("click", () => location.reload());
 backspaceBtn.addEventListener("click", handleBackspace);
 digitBtns.forEach(btn => {
-    btn.classList.add(btn.textContent);
+    btn.classList.add(`btn${btn.textContent}`);
     btn.addEventListener("click", displayDigit);
 });
 negativeBtn.addEventListener("click", () => display.value = display.value * -1);

--- a/script.js
+++ b/script.js
@@ -104,12 +104,12 @@ function handleBackspace() {
 
 function inputFromKeyboard(e) {
     console.log(e.key);
-    console.log(operatorBtns);
     // console.log(Array.from(operatorBtns));
 
+    let equivalentBtn;
     const inputIsDigit = !isNaN(e.key);
     if (inputIsDigit) {
-        const equivalentBtn = document.querySelector(`.btn${e.key}`);
+        equivalentBtn = document.querySelector(`.btn${e.key}`);
         equivalentBtn.dispatchEvent(new Event("mousedown"));
         equivalentBtn.click();
         return;
@@ -119,20 +119,29 @@ function inputFromKeyboard(e) {
         decimalBtn.click();
         return;
     };
-
-    const operatorMap = {
-        "+": "+",
-        "−": "-",
-        "×": ["*", "x", "X"],
-        "÷": "/"
-    };
-
-    const btnToKey = {
-        clearBtn: ["A", "a", "C", "c", "Escape"],
-        backspaceBtn: ["Backspace", "Delete"],
-        equalsBtn: ["Enter", "="],
-        decimalBtn: ".",
+    equivalentBtn = Array.from(allBtns).find((btn) => btn.textContent == e.key);
+    if (!equivalentBtn) {
+        console.log("btn not found");
+        return;
     }
+
+
+    console.log(equivalentBtn);
+
+    // const operatorMap = {
+    //     "+": "+",
+    //     "−": "-",
+    //     "×": ["*", "x", "X"],
+    //     "÷": "/"
+    // };
+    // console.log(Object.entries(operatorMap));
+
+    // const btnToKey = {
+    //     clearBtn: ["A", "a", "C", "c", "Escape"],
+    //     backspaceBtn: ["Backspace", "Delete"],
+    //     equalsBtn: ["Enter", "="],
+    //     decimalBtn: ".",
+    // }
 };
 
 

--- a/script.js
+++ b/script.js
@@ -57,13 +57,13 @@ function addDecimal() {
     const currentNum = display.value;
     const currentNumHasDecimalAlready = currentNum.includes(".");
 
+    if (currentNum.slice(-1) == ".") return display.value = currentNum.slice(0, -1);
     if (currentNum == 0 || !currentNumHasDecimalAlready) {
         display.value = `${currentNum}.`;
         displayNeedsClearing = false;
         return;
     };
     if (displayNeedsClearing) return decimalBtn.disabled = true;
-    if (currentNum.slice(-1) == ".") return display.value = currentNum.slice(0, -1);
 };
 
 function handleOperationBtnClick(e) {
@@ -138,4 +138,3 @@ holdBtns.forEach(btn => btn.addEventListener("click", () => btn.classList.toggle
 //TODO: (1) ADD EVENT LISTENER TO DOCUMENT. ONKEYUP. USE E.CODE(?). 
 
 //?HOW TO HAVE DISPLAYDIGIT TAKE IN THE DIGIT, AND NOT EVENT E PARAMETER??
-//!bug: can put in double decimals;

--- a/script.js
+++ b/script.js
@@ -113,7 +113,10 @@ function displayDigitOrDecimalWithKeyboard(e) {
     };
 };
 
-document.addEventListener("keydown", displayDigitOrDecimalWithKeyboard);
+document.body.addEventListener("keydown", displayDigitOrDecimalWithKeyboard);
+document.body.addEventListener("mouseup", () =>
+    digitBtns.forEach(btn => btn.classList.remove("btn-clicked")));
+
 clearBtn.addEventListener("click", () => location.reload());
 backspaceBtn.addEventListener("click", handleBackspace);
 digitBtns.forEach(btn => {
@@ -128,8 +131,6 @@ allBtns.forEach(btn => {
     btn.addEventListener("mousedown", () => btn.classList.toggle("btn-clicked"));
     btn.addEventListener("click", () => operatorBtns.forEach(b => b.classList.remove("btn-held")))
 });
-document.body.addEventListener("mouseup", () =>
-    digitBtns.forEach(btn => btn.classList.remove("btn-clicked")));
 
 // ? can this potentially be merged with the general event handler for operation buttons?
 operatorBtns.forEach(operatorBtn =>


### PR DESCRIPTION
as an alternative to mouse, can use keyboard to:

1. add digits
2. backspace/clear
3. use operators, including equals, and decimals

the thought in the code is to not touch the event listeners (mostly) for a button being fired by a "click" event. instead, have the button trigger the clicking of the equivalent button, which fires the downstream functions. i also needed to add mousedown events manually, as these are, right now, what triggers the buttons to look like they've been clicked or held down (eg for operators).